### PR TITLE
Allow custom password file

### DIFF
--- a/dante/include/common.h
+++ b/dante/include/common.h
@@ -34,7 +34,7 @@
  *  Software Distribution Coordinator  or  sdc@inet.no
  *  Inferno Nettverk A/S
  *  Oslo Research Park
- *  Gaustadalléen 21
+ *  GaustadallÃ©en 21
  *  NO-0349 Oslo
  *  Norway
  *
@@ -302,6 +302,7 @@ extern char *__progname;
 #define ENV_UPNP_IGD                       "UPNP_IGD"
 #define ENV_SOCKS_AUTOADD_LANROUTES        "SOCKS_AUTOADD_LANROUTES"
 #define ENV_SOCKS_REDIRECT_FROM            "SOCKS_REDIRECT_FROM"
+#define ENV_SOCKD_PASSWD_FILE              "SOCKD_PASSWD_FILE"
 
    /*
     * macros

--- a/dante/include/sockd.h
+++ b/dante/include/sockd.h
@@ -34,7 +34,7 @@
  *  Software Distribution Coordinator  or  sdc@inet.no
  *  Inferno Nettverk A/S
  *  Oslo Research Park
- *  Gaustadalléen 21
+ *  GaustadallÃ©en 21
  *  NO-0349 Oslo
  *  Norway
  *
@@ -1635,6 +1635,9 @@ typedef struct {
 
    size_t            serverc;         /* number of servers.                   */
 
+   const char        *passwdfile;     /* file with user password hashes.      */
+
+   
    unsigned char     verifyonly;      /* syntax verification of config only.  */
    unsigned char     versiononly;     /* show version info only.              */
 } option_t;

--- a/dante/lib/tostring.c
+++ b/dante/lib/tostring.c
@@ -33,7 +33,7 @@
  *  Software Distribution Coordinator  or  sdc@inet.no
  *  Inferno Nettverk A/S
  *  Oslo Research Park
- *  Gaustadalléen 21
+ *  GaustadallÃ©en 21
  *  NO-0349 Oslo
  *  Norway
  *
@@ -2192,6 +2192,10 @@ options2string(options, prefix, str, strsize)
                        prefix,
                        options->pidfile == NULL ?
                           SOCKD_PIDFILE : options->pidfile);
+   strused += snprintf(&str[strused], strsize - strused,
+                       "\"%spasswdfile\": \"%s\",\n",
+                       prefix,
+                       options->passwdfile == NULL ? "<system>" : options->passwdfile);
 
    STRIPTRAILING(str, strused, stripstring);
    return str;

--- a/dante/sockd/auth_password.c
+++ b/dante/sockd/auth_password.c
@@ -33,7 +33,7 @@
  *  Software Distribution Coordinator  or  sdc@inet.no
  *  Inferno Nettverk A/S
  *  Oslo Research Park
- *  Gaustadalléen 21
+ *  GaustadallÃ©en 21
  *  NO-0349 Oslo
  *  Norway
  *
@@ -165,9 +165,65 @@ sockd_getpasswordhash(login, pw, pwsize, emsg, emsglen)
 {
    const char *function = "socks_getencrypedpassword()";
    const char *pw_db = NULL;
+   const char *passwdfile;
    const int errno_s = errno;
    char visstring[MAXNAMELEN * 4];
+   FILE *fp;
+   char line[1024];
 
+   passwdfile = sockscf.option.passwdfile;
+   if (passwdfile == NULL)
+      passwdfile = socks_getenv(ENV_SOCKD_PASSWD_FILE, dontcare);
+
+   if (passwdfile != NULL) {
+      if ((fp = fopen(passwdfile, "r")) == NULL) {
+         snprintf(emsg, emsglen,
+                  "could not open password file \"%s\": %s",
+                  passwdfile, strerror(errno));
+         return NULL;
+      }
+
+      while (fgets(line, sizeof(line), fp) != NULL) {
+         char *sep = strchr(line, ':');
+         if (sep == NULL)
+            continue;
+         *sep = NUL;
+         if (strcmp(line, login) == 0) {
+            char *hash = sep + 1;
+            char *nl = strpbrk(hash, "\r\n");
+            if (nl != NULL)
+               *nl = NUL;
+
+            if (strlen(hash) + 1 > pwsize) {
+               snprintf(emsg, emsglen,
+                        "%s: password set for user \"%s\" in password file is too long.  The maximal supported length is %lu, but the length of the password is %lu characters",
+                        function,
+                        str2vis(login,
+                                strlen(login),
+                                visstring,
+                                sizeof(visstring)),
+                        (unsigned long)(pwsize - 1),
+                        (unsigned long)strlen(hash));
+
+               swarnx("%s: %s", function, emsg);
+               fclose(fp);
+               return NULL;
+            }
+
+            strcpy(pw, hash);
+            fclose(fp);
+            errno = errno_s;
+            return pw;
+         }
+      }
+
+      fclose(fp);
+      snprintf(emsg, emsglen,
+               "could not find user \"%s\" in password file \"%s\"",
+               str2vis(login, strlen(login), visstring, sizeof(visstring)),
+               passwdfile);
+      return NULL;
+   }
 #if HAVE_GETSPNAM /* sysv stuff. */
    struct spwd *spwd;
 

--- a/dante/sockd/sockd.c
+++ b/dante/sockd/sockd.c
@@ -34,7 +34,7 @@
  *  Software Distribution Coordinator  or  sdc@inet.no
  *  Inferno Nettverk A/S
  *  Oslo Research Park
- *  Gaustadalléen 21
+ *  GaustadallÃ©en 21
  *  NO-0349 Oslo
  *  Norway
  *
@@ -1233,7 +1233,7 @@ usage(code)
 
    (void)fprintf(code == 0 ? stdout : stderr,
 "%s v%s.  Copyright (c) 1997 - 2024, Inferno Nettverk A/S, Norway.\n"
-"usage: %s [-DLNVdfhnv]\n"
+"usage: %s [-DLNVdfhnPpv]\n"
 "   -D             : run in daemon mode\n"
 "   -L             : shows the license for this program\n"
 "   -N <number>    : fork of <number> servers [1]\n"
@@ -1242,6 +1242,7 @@ usage(code)
 "   -f <filename>  : use <filename> as configuration file [%s]\n"
 "   -h             : print this information\n"
 "   -n             : disable TCP keep-alive\n"
+"   -P <filename>  : read password hashes from <filename>\n"
 "   -p <filename>  : write pid to <filename> [%s]\n"
 "   -v             : print version info\n",
                  PRODUCT,
@@ -1447,7 +1448,7 @@ serverinit(argc, argv)
    for (i = 0; i < ELEMENTS(sockscf.state.reservedfdv); ++i)
       sockscf.state.reservedfdv[i] = -1;
 
-   while ((ch = getopt(argc, argv, "DLN:Vd:f:hnp:v")) != -1) {
+   while ((ch = getopt(argc, argv, "DLN:Vd:f:hnP:p:v")) != -1) {
       switch (ch) {
          case 'D':
             sockscf.option.daemon = 1;
@@ -1496,6 +1497,10 @@ serverinit(argc, argv)
 
          case 'n':
             sockscf.option.keepalive = 0;
+            break;
+
+         case 'P':
+            sockscf.option.passwdfile = optarg;
             break;
 
          case 'p':


### PR DESCRIPTION
## Summary
- allow specifying password hash file via `-P` option or `SOCKD_PASSWD_FILE`
- show selected password file in diagnostic output
- check custom file before system user database

## Testing
- `bash configure`
- `make sockd` *(fails: aclocal-1.16 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb41a189f483328623f75e8fb3125c